### PR TITLE
Partial throttle read2 advanced

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -316,7 +316,7 @@ public class AbfsConfiguration{
       FS_AZURE_ENABLE_ABFS_LIST_ITERATOR, DefaultValue = DEFAULT_ENABLE_ABFS_LIST_ITERATOR)
   private boolean enableAbfsListIterator;
 
-  @IntegerConfigurationValidatorAnnotation(ConfigurationKey ="fs.azure.min.bytes.should.read", DefaultValue =0)
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey ="fs.azure.min.bytes.should.read", DefaultValue =-1)
   private Integer minimumByteShouldBeRead;
 
   public AbfsConfiguration(final Configuration rawConfig, String accountName)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -316,6 +316,9 @@ public class AbfsConfiguration{
       FS_AZURE_ENABLE_ABFS_LIST_ITERATOR, DefaultValue = DEFAULT_ENABLE_ABFS_LIST_ITERATOR)
   private boolean enableAbfsListIterator;
 
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey ="fs.azure.min.bytes.should.read", DefaultValue =0)
+  private Integer minimumByteShouldBeRead;
+
   public AbfsConfiguration(final Configuration rawConfig, String accountName)
       throws IllegalAccessException, InvalidConfigurationValueException, IOException {
     this.rawConfig = ProviderUtils.excludeIncompatibleCredentialProviders(
@@ -509,6 +512,14 @@ public class AbfsConfiguration{
       Class<? extends U> defaultValue,
       Class<U> xface) {
     return rawConfig.getClass(name, defaultValue, xface);
+  }
+
+  public Integer getMinimumByteShouldBeRead() {
+    return minimumByteShouldBeRead;
+  }
+
+  public void setMinimumByteShouldBeRead(int minimumByteShouldBeRead) {
+    this.minimumByteShouldBeRead = minimumByteShouldBeRead;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpHeader.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpHeader.java
@@ -23,7 +23,11 @@ package org.apache.hadoop.fs.azurebfs.services;
  */
 public class AbfsHttpHeader {
   private final String name;
-  private final String value;
+  private  String value;
+
+  public void setValue(String value) {
+    this.value = value;
+  }
 
   public AbfsHttpHeader(final String name, final String value) {
     this.name = name;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -75,6 +75,9 @@ public class AbfsRestOperation {
   private AbfsHttpOperation result;
   private AbfsCounters abfsCounters;
 
+  private Boolean isIncomplete = false;
+  private Long dataRead = 0l;
+
   /**
    * Checks if there is non-null HTTP response.
    * @return true if there is a non-null HTTP response from the ABFS call.
@@ -230,6 +233,7 @@ public class AbfsRestOperation {
         LOG.debug("Retrying REST operation {}. RetryCount = {}",
             operationType, retryCount);
         Thread.sleep(client.getRetryPolicy().getRetryInterval(retryCount));
+        makeChangeInRequest();
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
       }
@@ -243,6 +247,34 @@ public class AbfsRestOperation {
     LOG.trace("{} REST operation complete", operationType);
   }
 
+  private void makeChangeInRequest() {
+    if(isIncomplete) {
+      for(AbfsHttpHeader header : requestHeaders) {
+        if(HttpHeaderConfigurations.RANGE.equals(header.getName())) {
+          long contentLength = 0;
+          final String RANGE_PREFIX = "bytes=";
+          String start, end;
+          String range = header.getValue();
+          // Format is "bytes=%d-%d"
+          if (range != null && range.startsWith(RANGE_PREFIX)) {
+            String[] offsets = range.substring(RANGE_PREFIX.length()).split("-");
+            if (offsets.length == 2) {
+              start = offsets[0];
+              end = offsets[1];
+              contentLength = Long.parseLong(offsets[1]) - Long.parseLong(offsets[0])
+                  + 1;
+
+              String headerNewVal = RANGE_PREFIX + (Long.parseLong(start) + dataRead);
+              bufferOffset+=dataRead;
+              header.setValue(headerNewVal);
+            }
+          }
+          return;
+        }
+      }
+    }
+  }
+
   /**
    * Executes a single HTTP operation to complete the REST operation.  If it
    * fails, there may be a retry.  The retryCount is incremented with each
@@ -250,6 +282,7 @@ public class AbfsRestOperation {
    */
   private boolean executeHttpOperation(final int retryCount,
     TracingContext tracingContext) throws AzureBlobFileSystemException {
+    isIncomplete = false;
     AbfsHttpOperation httpOperation = null;
     try {
       // initialize the HTTP request and open the connection
@@ -309,6 +342,9 @@ public class AbfsRestOperation {
         double percentage = ((double) (httpOperation.getBytesReceived())/bytesExpected) * 100d;
 
         if(httpOperation.getStatusCode() == HttpURLConnection.HTTP_PARTIAL && (percentage <= client.getAbfsConfiguration().getMinimumByteShouldBeRead())) {
+          isIncomplete = true;
+          dataRead = httpOperation.getBytesReceived();
+          LOG.info("incomplete data Read: " + dataRead + "; percentage: " + percentage);
           if (!client.getRetryPolicy().shouldRetry(retryCount, -1)) {
             throw new InvalidAbfsRestOperationException(new Exception("can not be retried more."));
           }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -78,6 +78,8 @@ public class AbfsRestOperation {
   private Boolean isIncomplete = false;
   private Long dataRead = 0l;
 
+  private Long totalIncompleteDataRead = 0l;
+
   /**
    * Checks if there is non-null HTTP response.
    * @return true if there is a non-null HTTP response from the ABFS call.
@@ -268,6 +270,7 @@ public class AbfsRestOperation {
               LOG.info("new range: " + headerNewVal);
               bufferOffset+=dataRead;
               bufferLength-= dataRead;
+              totalIncompleteDataRead += dataRead;
               header.setValue(headerNewVal);
             }
           }
@@ -350,6 +353,7 @@ public class AbfsRestOperation {
           if (!client.getRetryPolicy().shouldRetry(retryCount, -1)) {
             throw new InvalidAbfsRestOperationException(new Exception("can not be retried more."));
           }
+
           return false;
         }
         if(httpOperation.getStatusCode() == HttpURLConnection.HTTP_PARTIAL) {
@@ -401,6 +405,8 @@ public class AbfsRestOperation {
     }
 
     result = httpOperation;
+
+    result.setBytesReceived(result.getBytesReceived()  + totalIncompleteDataRead);
 
     return true;
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -264,8 +264,10 @@ public class AbfsRestOperation {
               contentLength = Long.parseLong(offsets[1]) - Long.parseLong(offsets[0])
                   + 1;
 
-              String headerNewVal = RANGE_PREFIX + (Long.parseLong(start) + dataRead);
+              String headerNewVal = RANGE_PREFIX + (Long.parseLong(start) + dataRead) + "-" + end;
+              LOG.info("new range: " + headerNewVal);
               bufferOffset+=dataRead;
+              bufferLength-= dataRead;
               header.setValue(headerNewVal);
             }
           }
@@ -349,6 +351,9 @@ public class AbfsRestOperation {
             throw new InvalidAbfsRestOperationException(new Exception("can not be retried more."));
           }
           return false;
+        }
+        if(httpOperation.getStatusCode() == HttpURLConnection.HTTP_PARTIAL) {
+          LOG.info("data percentage" + percentage + "; bytesExpected" + bytesExpected);
         }
       } else if (httpOperation.getStatusCode() == HttpURLConnection.HTTP_UNAVAILABLE) {
         incrementCounter(AbfsStatistic.SERVER_UNAVAILABLE, 1);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestPartialRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestPartialRead.java
@@ -271,7 +271,7 @@ public class ITestPartialRead extends AbstractAbfsIntegrationTest {
             mockHttpOperationTestInterceptResult
             = new MockHttpOperationTestInterceptResult();
         mockHttpOperationTestInterceptResult.setStatus(HTTP_PARTIAL);
-        mockHttpOperationTestInterceptResult.setBytesRead(4*ONE_MB);
+        mockHttpOperationTestInterceptResult.setBytesRead(ONE_MB);
         callCount++;
         return mockHttpOperationTestInterceptResult;
       }
@@ -290,7 +290,7 @@ public class ITestPartialRead extends AbstractAbfsIntegrationTest {
     inputStream.read(0, buffer, 0, fileSize);
     Assertions.assertThat(mockHttpOperationTestIntercept.getCallCount())
         .describedAs("Number of server calls is wrong")
-        .isEqualTo(1);
+        .isEqualTo(4);
     Assertions.assertThat(analyzerToBeAsserted.getFailedInstances().intValue())
         .describedAs(
             "Number of server calls counted as throttling case is incorrect")


### PR DESCRIPTION

### Description of PR

New key added:
fs.azure.min.bytes.should.read
Define the minimum percentage of data-required should be read to skip exponential retry. For example, if the config-value is 50, the request was for 4MB, but got 1MB -> it will do an exponential retry for the remaining 3MB(would add metric in throttling analyser). If the request was 4MB but got 3 MB -> it WONT do an exponential retry for the remaining 1MB(would add metric in throttling analyser)

Keep the value to -1 to avoid using the change.


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

